### PR TITLE
Mpi jureca issues

### DIFF
--- a/propti/basic_functions.py
+++ b/propti/basic_functions.py
@@ -228,6 +228,12 @@ def extract_simulation_data(setup: SimulationSetup):
 
     logging.debug("execution directory: {}".format(setup.execution_dir))
 
+    if os.path.exists(os.path.join(setup.execution_dir, 'wct.csv')):
+        wct_file = open(os.path.join(setup.execution_dir, 'wct.csv'))
+        line = wct_file.readline()
+        wct_file.close()
+        logging.debug("WCT info: {}".format(line))
+
     for r in setup.relations:
         r.read_data(setup.execution_dir)
 

--- a/propti/basic_functions.py
+++ b/propti/basic_functions.py
@@ -165,9 +165,7 @@ def run_simulation_serial(setup: SimulationSetup,
     in_file = setup.model_input_file
     log_file = open(os.path.join(new_dir, "execution.log"), "w")
 
-    # cmd = 'cd {}; {} {}'.format(new_dir, exec_file, in_file)
     cmd = 'cd {} && {} {}'.format(new_dir, exec_file, in_file)
-    # cmd = ["cd {}".format(new_dir), " {} {}".format(exec_file, in_file)]
 
     logging.debug("executing command: {}".format(cmd))
 

--- a/propti_run.py
+++ b/propti_run.py
@@ -6,9 +6,14 @@ import pandas as pd
 import shutil as sh
 import pickle
 
-import propti as pr
+from mpi4py import MPI
 
+comm = MPI.COMM_WORLD
+print('starting propti on MPI rank {} out of {} ranks'.format(comm.Get_rank(), comm.Get_size()))
+
+import propti as pr
 import logging
+
 
 import argparse
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
resolves (hopefully) JURECA issues with serial execution of FDS and MPI timeouts

just for documentation, the executable wrapper on JURECA:

#!/usr/bin/sh

env -i bash -l -c "
echo 'running FDS'

echo 'loading modules'
module use -a ~arnold1/modules_fire/
module load FDS/6.7.0-IntelCompiler_2019.0_ParaStationMPI_5.2.1

which fds

if [ \"$#\" -eq 0 ]; then
    echo | OMP_NUM_THREADS=1 fds
else
    OMP_NUM_THREADS=1 fds $1
    wct=\`grep 'Total Elapsed Wall Clock Time' *.out | cut -d: -f2\`
    hostname=`hostname`
    dir=${PWD##*}
    date=\`date\`
    echo \"`date`; `hostname`; \`grep 'Total Elapsed Wall Clock Time' *.out | cut -d: -f2\`; `pwd` \"  > wct.csv
fi
" 