### PR TITLE
Changed init to finished, to read correct propti file

### DIFF
--- a/propti_analyse.py
+++ b/propti_analyse.py
@@ -129,7 +129,7 @@ print("----------------------")
 #     sys.exit("Neither 'propti.pickle.finished' nor 'propti.pickle.init' "
 #              "detected. Script execution stopped.")
 
-pickle_file = os.path.join(cmdl_args.root_dir, 'propti.pickle.init')
+pickle_file = os.path.join(cmdl_args.root_dir, 'propti.pickle.finished')
 
 in_file = open(pickle_file, 'rb')
 


### PR DESCRIPTION
Problem: 
During running `propti_analyse.py` one ends up having `None` values for best parameters after running the IMP. These `None` values are substituted back into the template file when running `--create_best_input` and `--run_best`, thereby causing an error.

Solution:
This is because the wrong file was being read.

