### PR TITLE
Bug fix of decode of utf-8

### DIFF
--- a/propti/data_structures.py
+++ b/propti/data_structures.py
@@ -816,7 +816,7 @@ class Version:
             # define maximal number of line to be parsed
             lines_count = 100
             while True:
-                line = proc.stdout.readline().decode("utf-8")
+                line = proc.stdout.readline().decode("utf-8", "ignore")
                 if line[1:9] == 'Revision':
                     ver = line[line.index(':')+2:]
                     break


### PR DESCRIPTION
I tried to do preparation but the error "decode of utf-8" occurred. I found add "ignore" could fix this bug