### PR TITLE
Allow downwards compatibility to Python below 3.9

### DIFF
--- a/propti/data_structures.py
+++ b/propti/data_structures.py
@@ -381,7 +381,7 @@ class ParameterSet:
                 if not skip_evaluation:
                     combined_vars = local_vars
                     if p.evaluate_dict:
-                        combined_vars = combined_vars | p.evaluate_dict
+                        combined_vars = dict(combined_vars.items() | p.evaluate_dict.items())
                     result = eval(p.evaluate_value, combined_vars)
                     print(f'  resulting value {result}')
                     p.value = float(result)


### PR DESCRIPTION
@lu-kas please check if it does the same as you intended. Combining two dicts is only possible from Python 3.9 on. In my proposal you get two lists, combine them and make a dict from it.