### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+*.md
+*.txt
+examples
+docker
+!VERSION.txt
+!.git/refs/heads/master

--- a/.github/workflows/deploy.nightly.yaml
+++ b/.github/workflows/deploy.nightly.yaml
@@ -1,0 +1,47 @@
+name: Deploy Propti Nightly
+on:
+  repository_dispatch:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'FDS version'
+        required: true
+        type: string
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: propti-nightly
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          provenance: false
+          file: docker/Dockerfile.nightly
+          build-args: |
+            FDS_VERSION=${{ inputs.tag }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,9 +19,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Check compatibility (minimum FDS version should be 6.7.1)
+      - name: Check compatibility (minimum FDS version should be 6.7.4)
         run: |
-          if $(printf '%s\n%s\n' "6.7.1" "${{ inputs.tag }}" | sort --check=quiet --version-sort)
+          if [ "${{ inputs.tag }}" \> "6.7.3" ]
           then
             exit 0
           fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,81 @@
+name: Deploy Propti
+on:
+  repository_dispatch:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'FDS version'
+        required: true
+        type: string
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: propti
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    env:
+      IS_LATEST: true
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check compatibility (minimum FDS version should be 6.7.1)
+        run: |
+          if $(printf '%s\n%s\n' "6.7.1" "${{ inputs.tag }}" | sort --check=quiet --version-sort)
+          then
+            exit 0
+          fi
+          exit 1
+      - name: Extract image name
+        run: echo "BASE=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${BASE}
+      - name: Check if new build version is latest
+        continue-on-error: true
+        run: |
+          REGEX=[0-9]+\.[0-9]+\.[0-9]+
+          LATEST_VERSION=0.0.0
+          VERSIONS=$(curl --silent "https://api.github.com/users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions" --stderr - \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" | \
+            grep -E "[[:space:]]+\"${REGEX}\"" | grep -oEi ${REGEX})
+          for VERSION in $VERSIONS; do
+            [ "$VERSION" \> "$LATEST_VERSION" ] && LATEST_VERSION=$VERSION
+          done
+          if [ "${{ inputs.tag }}" \< "${LATEST_VERSION}" ]
+          then
+            echo "IS_LATEST=false" >> $GITHUB_ENV
+          fi
+      - name: Set Tags
+        run: |
+          if [[ ${{ env.IS_LATEST }} == true ]]
+          then
+            echo "TAGS=${BASE}:${{ inputs.tag }},${BASE}:latest" >> $GITHUB_ENV
+          else
+            echo "TAGS=${BASE}:${{ inputs.tag }}" >> $GITHUB_ENV
+          fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          provenance: false
+          file: docker/Dockerfile
+          build-args: |
+            FDS_VERSION=${{ inputs.tag }}
+          push: true
+          tags: ${{ env.TAGS }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/update.nightly.yaml
+++ b/.github/workflows/update.nightly.yaml
@@ -1,0 +1,31 @@
+name: Update All Propti Nightly Images
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - '**.py'
+      - '.dockerignore'
+      - 'docker/Dockerfile.nightly'
+env:
+  IMAGE_NAME: propti-nightly
+jobs:
+  trigger-updates:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      actions: write
+    steps:
+      - name: Extract available docker image versions and trigger build
+        continue-on-error: true
+        run: |
+          REGEX=[0-9]+\.[0-9]+\.[0-9]+
+          VERSIONS=$(curl --silent "https://api.github.com/users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions" --stderr - \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" | \
+            grep -E "[[:space:]]+\"${REGEX}\"" | grep -oEi ${REGEX})
+          for VERSION in ${VERSIONS}; do
+            curl -L -X POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy.nightly.yaml/dispatches \
+            -d "{\"ref\":\"master\",\"inputs\": {\"tag\": \"${VERSION}\"}}"
+          done

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,31 @@
+name: Update All Propti Images
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - '**.py'
+      - '.dockerignore'
+      - 'docker/Dockerfile'
+env:
+  IMAGE_NAME: propti
+jobs:
+  trigger-updates:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      actions: write
+    steps:
+      - name: Extract available docker image versions and trigger build
+        continue-on-error: true
+        run: |
+          REGEX=[0-9]+\.[0-9]+\.[0-9]+
+          VERSIONS=$(curl --silent "https://api.github.com/users/${{ github.repository_owner }}/packages/container/${{ env.IMAGE_NAME }}/versions" --stderr - \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" | \
+            grep -E "[[:space:]]+\"${REGEX}\"" | grep -oEi ${REGEX})
+          for VERSION in ${VERSIONS}; do
+            curl -L -X POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/deploy.yaml/dispatches \
+            -d "{\"ref\":\"master\",\"inputs\": {\"tag\": \"${VERSION}\"}}"
+          done

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -1,8 +1,8 @@
-# FDS version (default: latest), e.g. 6.9.1
-ARG FDS_VERSION=latest
+# FDS version
+ARG FDS_VERSION
 
 # FDS base image
-FROM ghcr.io/openbcl/fds:${FDS_VERSION}
+FROM ghcr.io/openbcl/fds-nightly:${FDS_VERSION}
 
 # install app dependencies
 RUN apt-get update && apt-get install -y libmpich-dev python3-pip python3.10-venv

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -38,7 +38,7 @@ There you will find all information on options, problems, errors and their solut
 1. Clone this repository.
 1. Navigate with your shell to this folder.
 1. Choose between building the image with the latest FDS version or with a specific one. You can find all available versions (tags) [here](https://github.com/openbcl/fds-dockerfiles/pkgs/container/fds/versions).
-For compatibility reasons, the FDS version should be at least 6.7.1.
+For compatibility reasons, the FDS version should be at least 6.7.4.
 
 ```bash
 # build command: propti image with latest FDS version

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,6 +1,51 @@
-* build command:
-docker build -t propti .
+## Run propti interactive
+```bash
+# Linux
+docker run -it -v $(pwd):/workdir ghcr.io/FireDynamics/propti
 
-* run command:
-[Linux]   docker run -ti -v $PWD:/workdir propti
-[Windows / Powershell] docker run -ti -v ${PWD}:/workdir propti
+# Windows PowerShell
+docker run --it -v ${pwd}:/workdir ghcr.io/FireDynamics/propti
+
+# Windows Command Prompt
+docker run -it -v %cd%:/workdir ghcr.io/FireDynamics/propti
+```
+
+You can now use propti with the following commands:
+- `propti_analyse <...arguments>`
+- `propti_prepare <input-filename>`
+- `propti_run .`
+- `propti_sense .`
+
+You can display the help for each command by using the `-h` argument (e.g. `propti_analyse -h`).
+
+## Run propti non-interactive
+```bash
+# Linux
+docker run --rm -v $(pwd):/workdir ghcr.io/FireDynamics/propti {propti_analyse|propti_prepare|propti_run|propti_sense} <...arguments>
+
+# Windows PowerShell
+docker run --rm -v ${pwd}:/workdir ghcr.io/FireDynamics/propti {propti_analyse|propti_prepare|propti_run|propti_sense} <...arguments>
+
+# Windows Command Prompt
+docker run --rm -v %cd%:/workdir ghcr.io/FireDynamics/propti {propti_analyse|propti_prepare|propti_run|propti_sense} <...arguments>
+```
+
+## Additional information
+This docker image is based on the FDS image [ghcr.io/openbcl/fds](https://github.com/openbcl/fds-dockerfiles/pkgs/container/fds).
+There you will find all information on options, problems, errors and their solutions when operating FDS in Docker containers.
+
+## How to build the docker image by yourself
+1. Clone this repository.
+1. Navigate with your shell to this folder.
+1. Choose between building the image with the latest FDS version or with a specific one. You can find all available versions (tags) [here](https://github.com/openbcl/fds-dockerfiles/pkgs/container/fds/versions).
+For compatibility reasons, the FDS version should be at least 6.7.1.
+
+```bash
+# build command: propti image with latest FDS version
+docker build -t propti -f Dockerfile ..
+
+# build command: propti image with specific FDS version (e.g. 6.9.1)
+docker build --build-arg="FDS_VERSION=6.9.1" -t propti -f Dockerfile .. 
+```
+
+To run your docker image of propti use the `docker run` commands described above and replace the package name `ghcr.io/FireDynamics/propti` with `propti`.

--- a/propti_analyse.py
+++ b/propti_analyse.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import pandas as pd
 import pickle

--- a/propti_prepare.py
+++ b/propti_prepare.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import numpy as np

--- a/propti_run.py
+++ b/propti_run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import numpy as np

--- a/propti_sense.py
+++ b/propti_sense.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import numpy as np
 import propti as pr
 


### PR DESCRIPTION
Hello everyone, @TristanHehnen  and @lu-kas!

A while ago I told you about my idea to revise the Docker image in this repository.

## Changes
1. I have added so-called [shebangs](https://en.wikipedia.org/wiki/Shebang_(Unix)) to the main python files (`#!/usr/bin/env python3`). This allows the files to be executed directly in unix based systems without a preceding `python` command.
2. I have modified the Dockerfile so that it extends the FDS Docker image provided by [openbcl/fds-dockerfiles](https://github.com/openbcl/fds-dockerfiles). In addition, an argument with the required FDS version can be passed when building the image. In this way, a Propti Docker image can be created very easily for different FDS versions. You will find the relevant instructions in the corresponding *readme.md* file. I have also created a nightly version of the Dockerfile. This can be used to run Propti in combination with an [FDS Test Bundle](https://github.com/firemodels/fds/wiki/FDS-Test-Bundles). This allows Propti to be tested with new and unreleased FDS features.
3. I have created four workflows so that the Propti Docker images can be provided fully automatically through this repository in future.

## Workflow Details
### Deploy Propti: `.github/workflows/deploy.yaml`
After merging this Pull request this workflow can be triggered manually by the repository owner using the [Actions tab](https://github.com/FireDynamics/propti/actions) by specifying an FDS version number (at least 6.7.4). This action will build and push Propti  to the packages section of this repository as a Docker image.

Furthermore, this workflow can be triggered by [openbcl/fds-dockerfiles](https://github.com/openbcl/fds-dockerfiles) as soon as a new FDS version is published there. This would allow the Docker images for Propti to be generated and kept up to date fully automatically without your intervention. However, a token with read permissions for the Propti repository must be provided to openbcl for this purpose. This is straightforward. **However, we should have a phone call about this.**

### Deploy Propti Nightly: `.github/workflows/deploy.nightly.yaml`
This workflow has the same functionality as the previous one. However, it builds and pushes a Propti nightly image, which contains the current nightly version of FDS for testing purposes.

### Update All Propti Images: `.github/workflows/update.yaml`
This workflow is triggered fully automatically as soon as files with the *.py* extension are updated in the master branch of this repository. The same applies to adjustments to the *.dockerignore* file or the individual *Dockerfiles* in the docker folder. The workflow reads all previously published versions of Propti images in this repository and ensures that they are rebuilt and pushed again. This ensures that the source code is always kept up to date for all Docker images of Propti. You can therefore continue to develop Propti without having to worry about the Docker images of Propti becoming obsolete.

### Update All Propti Nightly Images: `.github/workflows/update.nightly.yaml`
This workflow has the same functionality as the previous one. However, it rebuilds and pushes all Propti nightly images, which contain nightly versions of FDS for testing purposes.

---

Kind regards
Robert