### PR TITLE
Enable parallel propti runs in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,12 @@ ARG FDS_VERSION=latest
 # FDS base image
 FROM ghcr.io/openbcl/fds:${FDS_VERSION}
 
+# Enable mpiexec.openmpi run as root
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 # install app dependencies
-RUN apt-get update && apt-get install -y libmpich-dev python3-pip python3-venv
+RUN apt-get update && apt-get install -y libopenmpi-dev python3-pip python3-venv
 
 # create python venv for propti
 RUN python3 -m venv /opt/venv/propti

--- a/docker/Dockerfile.nightly
+++ b/docker/Dockerfile.nightly
@@ -4,8 +4,12 @@ ARG FDS_VERSION
 # FDS base image
 FROM ghcr.io/openbcl/fds-nightly:${FDS_VERSION}
 
+# Enable mpiexec.openmpi run as root
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 # install app dependencies
-RUN apt-get update && apt-get install -y libmpich-dev python3-pip python3-venv
+RUN apt-get update && apt-get install -y libopenmpi-dev python3-pip python3-venv
 
 # create python venv for propti
 RUN python3 -m venv /opt/venv/propti

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -16,7 +16,12 @@ You can now use propti with the following commands:
 - `propti_run .`
 - `propti_sense .`
 
-You can display the help for each command by using the `-h` argument (e.g. `propti_analyse -h`).
+*You can display the help for each command by using the `-h` argument (e.g. `propti_analyse -h`).*
+
+If you would like to run the `propti_run` command in parallel via mpi, you can start it as follows:
+```bash
+mpiexec.openmpi -n <number of processes> propti_run .
+```
 
 ## Run propti non-interactive
 ```bash


### PR DESCRIPTION
Hi @TristanHehnen,

During our BESKID team meeting at the weekend, we realised that propti cannot yet be executed in parallel within the Docker container using mpiexec.

I have solved the problem and would be very grateful if you could merge this pull request so that we can run propti faster at BCL.

*It was due to the Python package mpi4py, which is provided by default via PIP for OpenMPI and not for Intel MPI. I have therefore now replaced ‘libmpich-dev’ with ‘libopenmpi-dev’. The FDS simulation itself is still parallelised by Intel MPI.*

The propti images will then be rebuilt automatically.

Kind regards
Robert